### PR TITLE
Convert octants to degrees

### DIFF
--- a/wreport/conv-tut.cc
+++ b/wreport/conv-tut.cc
@@ -54,6 +54,10 @@ std::vector<Test> tests {
 
         ensure_equals(convert_units("J/M**2", "MJ/M**2", 1), 0.000001);
         ensure_equals(convert_units("MJ/M**2", "J/M**2", 1), 1000000);
+
+        ensure_equals(convert_units("octants", "DEGREE TRUE", 0), 0);
+        ensure_equals(convert_units("octants", "DEGREE TRUE", 1), 45);
+        ensure_equals(convert_units("DEGREE TRUE", "octants", 45), 1);
     }),
     Test("vss", [](Fixture& f) {
         // Vertical sounding significance conversion functions

--- a/wreport/conv.cc
+++ b/wreport/conv.cc
@@ -33,6 +33,15 @@ struct ConvertLinear : public Convert
     double convert(double val) const override { return val * mul + add; }
 };
 
+struct ConvertFunction : public Convert
+{
+    std::function<double(double)> conv;
+
+    ConvertFunction(std::function<double(double)> conv) : conv(conv) {}
+
+    double convert(double val) const override { return conv(val); }
+};
+
 struct Conv
 {
     const char* from;
@@ -200,6 +209,14 @@ struct ConvertRepository
     {
         repo.emplace_back(from, to, new ConvertLinear(mul, add));
         repo.emplace_back(to, from, new ConvertLinear(1/mul, -add));
+    }
+
+    void add_function(const char* from, const char* to,
+                      std::function<double(double)> forward,
+                      std::function<double(double)> backward)
+    {
+        repo.emplace_back(from, to, new ConvertFunction(forward));
+        repo.emplace_back(to, from, new ConvertFunction(backward));
     }
 
     const Convert* find(const char* from, const char* to)

--- a/wreport/conv.cc
+++ b/wreport/conv.cc
@@ -191,6 +191,7 @@ struct ConvertRepository
         add_ident("GPM",          "MGP");
         add_ident("W/m**2",       "W/M**2");
         add_ident("J M-2",        "J/M**2");
+        add_function("octants",   "DEGREE TRUE", convert_octants_to_degrees, convert_degrees_to_octants);
 
         sort(repo.begin(), repo.end());
     }


### PR DESCRIPTION
Added automatic conversion from `octants` to `DEGREE TRUE`.

The implementation relies on `ConvertFunction`, that takes two `std::functions<double(double)>` (forward and backward conversion) as parameters.