### PR TITLE
Install python package with pip

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -8,7 +8,7 @@ wreport_module = Extension(
     ],
     language="c++",
     extra_compile_args=['-std=c++11'],
-    libraries=['wreport', 'lua5.2'],
+    libraries=['wreport', 'lua'],
 )
 
 setup(

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,19 +1,14 @@
-from setuptools import Extension, setup, command
-import os.path
-
-
-pydir = os.path.dirname(__file__)
+from setuptools import Extension, setup
 
 
 wreport_module = Extension(
-    'wreport',
+    '_wreport',
     sources=[
-        os.path.join(pydir, f) for f in [
-            "common.cc", "varinfo.cc", "vartable.cc", "var.cc", "wreport.cc",
-        ]
+        "common.cc", "varinfo.cc", "vartable.cc", "var.cc", "wreport.cc",
     ],
     language="c++",
     extra_compile_args=['-std=c++11'],
+    libraries=['wreport', 'lua5.2'],
 )
 
 setup(
@@ -28,7 +23,7 @@ setup(
     url="http://github.com/arpa-simc/wreport",
     license="GPLv2+",
     py_modules=[],
-    packages=[],
+    packages=['wreport'],
     data_files=[],
     zip_safe=False,
     include_package_data=True,

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,14 +1,21 @@
 from setuptools import Extension, setup
+import subprocess
+
+
+def pkg_config_flags(options):
+    return [
+        s for s in subprocess.check_output(['pkg-config'] + options + ['libwreport']).decode().strip().split(" ") if s
+    ]
 
 
 wreport_module = Extension(
     '_wreport',
     sources=[
-        "common.cc", "varinfo.cc", "vartable.cc", "var.cc", "wreport.cc",
+        "common.cc", "varinfo.cc", "vartable.cc", "var.cc", "wreport.cc"
     ],
     language="c++",
-    extra_compile_args=['-std=c++11'],
-    libraries=['wreport', 'lua'],
+    extra_compile_args=pkg_config_flags(["--cflags"]) + ["-std=c++11"],
+    extra_link_args=pkg_config_flags(["--libs"]),
 )
 
 setup(


### PR DESCRIPTION
Using pip is the only way I know to install this package in a virtualenv.

From source code (using `setuptools` branch):

    $ pip install -e "git+https://github.com/arpa-simc/wreport.git@setuptools#egg=wreport&subdirectory=python"

But the package could be pushed in pypi and the installation is simpler

    $ pip install wreport

**Note** I commited a buggy `setup.py` in `master` branch, sorry.