### PR TITLE
Use Requires in libwreport.pc when needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,23 +89,24 @@ AC_SUBST(PKGCONFIG_LIBS)
 AC_SUBST(PKGCONFIG_REQUIRES)
 
 dnl Check for lua
+PKGCONFIG_LUA_MODULE="lua >= 5.1.1"
 PKG_CHECK_EXISTS([lua5.2], [have_lua=yes], [have_lua=no])
 if test x$have_lua = xyes
 then
         PKG_CHECK_MODULES(LUA,lua5.2,,[have_lua=no])
-        PKGCONFIG_REQUIRES="$PKGCONFIG_REQUIRES lua >= 5.1"
+        PKGCONFIG_REQUIRES="$PKGCONFIG_REQUIRES $PKGCONFIG_LUA_MODULE"
 else
 	PKG_CHECK_EXISTS([lua5.1], [have_lua=yes], [have_lua=no])
 	if test x$have_lua = xyes
 	then
 		PKG_CHECK_MODULES(LUA,lua5.1,,[have_lua=no])
-        PKGCONFIG_REQUIRES="$PKGCONFIG_REQUIRES lua >= 5.1"
+        PKGCONFIG_REQUIRES="$PKGCONFIG_REQUIRES $PKGCONFIG_LUA_MODULE"
 	else
 		PKG_CHECK_EXISTS([lua], [have_lua=yes], [have_lua=no])
 		if test x$have_lua = xyes
 		then
-			PKG_CHECK_MODULES(LUA,[lua >= 5.1],,[have_lua=no])
-            PKGCONFIG_REQUIRES="$PKGCONFIG_REQUIRES lua >= 5.1"
+			PKG_CHECK_MODULES(LUA,[$PKGCONFIG_LUA_MODULE],,[have_lua=no])
+            PKGCONFIG_REQUIRES="$PKGCONFIG_REQUIRES $PKGCONFIG_LUA_MODULE"
 		else
 			dnl We don't always have the luxury of .pc files for lua, it seems
 			have_lua=yes

--- a/configure.ac
+++ b/configure.ac
@@ -83,24 +83,29 @@ then
 	fi
 fi
 
-DEP_LIBS=""
-AC_SUBST(DEP_LIBS)
+PKGCONFIG_LIBS="-lm"
+PKGCONFIG_REQUIRES=""
+AC_SUBST(PKGCONFIG_LIBS)
+AC_SUBST(PKGCONFIG_REQUIRES)
 
 dnl Check for lua
 PKG_CHECK_EXISTS([lua5.2], [have_lua=yes], [have_lua=no])
 if test x$have_lua = xyes
 then
         PKG_CHECK_MODULES(LUA,lua5.2,,[have_lua=no])
+        PKGCONFIG_REQUIRES="$PKGCONFIG_REQUIRES lua >= 5.1"
 else
 	PKG_CHECK_EXISTS([lua5.1], [have_lua=yes], [have_lua=no])
 	if test x$have_lua = xyes
 	then
 		PKG_CHECK_MODULES(LUA,lua5.1,,[have_lua=no])
+        PKGCONFIG_REQUIRES="$PKGCONFIG_REQUIRES lua >= 5.1"
 	else
 		PKG_CHECK_EXISTS([lua], [have_lua=yes], [have_lua=no])
 		if test x$have_lua = xyes
 		then
-			PKG_CHECK_MODULES(LUA,lua,,[have_lua=no])
+			PKG_CHECK_MODULES(LUA,[lua >= 5.1],,[have_lua=no])
+            PKGCONFIG_REQUIRES="$PKGCONFIG_REQUIRES lua >= 5.1"
 		else
 			dnl We don't always have the luxury of .pc files for lua, it seems
 			have_lua=yes
@@ -108,13 +113,13 @@ else
 			AC_CHECK_HEADER([lua.h], [true], [have_lua=no])
 			LUA_CFLAGS=
 			LUA_LIBS="-llua"
+            PKGCONFIG_LIBS="$PKGCONFIG_LIBS $LUA_LIBS"
 		fi
 	fi
 fi
 if test x$have_lua = xyes
 then
         AC_DEFINE([HAVE_LUA], 1, [lua is available])
-        DEP_LIBS="$DEP_LIBS $LUA_LIBS"
 fi
 AM_CONDITIONAL([LUA], [test x"$have_lua" = x"yes"])
 

--- a/fedora/SPECS/wreport.spec
+++ b/fedora/SPECS/wreport.spec
@@ -60,7 +60,7 @@ libwreport is a C++ library to read and write weather reports in BUFR and CREX
 %package -n lib%{name}-devel
 Summary:  Library for working with (coded) weather reports
 Group: Applications/Meteo
-Requires: lib%{name}3 = %{version}, lua-devel >= 5.1.1
+Requires: lib%{name}3 = %{version}
 
 %description -n lib%{name}-devel
 libwreport is a C++ library to read and write weather reports in BUFR and CREX

--- a/libwreport.pc.in
+++ b/libwreport.pc.in
@@ -9,5 +9,6 @@ tabledir=@tabledir@
 Name: libwreport
 Description: Weather report library
 Version: @VERSION@
+Requires: @PKGCONFIG_REQUIRES@
 Cflags: -I${includedir}
-Libs: -L${libdir} -lwreport @DEP_LIBS@
+Libs: -L${libdir} -lwreport @PKGCONFIG_LIBS@


### PR DESCRIPTION
@spanezz I ask you to review this PR because I'll use these changes as a template for the `.pc` files of the other libraries (dballe, arkimet, etc) if you approve them.

The `Requires` keyword in the `.pc` files is processed by `rpmbuild` to add automatic dependencies to `-devel` packages.

Fix #19 