### PR TITLE
Var.get doc (fix #44)

### DIFF
--- a/python/var.cc
+++ b/python/var.cc
@@ -309,7 +309,7 @@ struct get : public MethKwargs<get, wrpy_Var>
     constexpr static const char* name = "get";
     constexpr static const char* signature = "default: Any=None";
     constexpr static const char* returns = "Union[str, float, long, Any]";
-    constexpr static const char* summary = "get the value of the variable. If the variable is unset, ``default`` is returned";
+    constexpr static const char* summary = "get the value of the variable, as int, float or str according the variable definition. If the variable is unset, ``default`` is returned";
 
     static PyObject* run(Impl* self, PyObject* args, PyObject* kw)
     {


### PR DESCRIPTION
Ho usato la documentazione di https://arpa-simc.github.io/wreport/python/wreport.html#wreport.Var.enq, che mi pareva abbastanza chiara.

Per tenerla breve, non ho specificato che si possono usare i metodi enqc, enqd, enqi ([come suggerito da @pat1](https://github.com/ARPA-SIMC/dballe/issues/188#issuecomment-871534336)) - anche perché sono due righe sopra nella medesima pagina https://arpa-simc.github.io/wreport/python/wreport.html#wreport.Var.